### PR TITLE
Change /uploads target directory

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,7 +25,7 @@ app.use(
 );
 
 app.use(express.static(path.join(__dirname, "public")));
-app.use("/uploads", express.static(__dirname));
+app.use("/uploads", express.static(path.join(__dirname, "public/uploads")))
 
 app.use(cors(corsOptions));
 

--- a/src/middlewares/lib/upload.js
+++ b/src/middlewares/lib/upload.js
@@ -23,8 +23,7 @@ const fileFilter = (req, file, cb) => {
 
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
-    const rootDir = path.dirname(require.main.filename);
-
+    const rootDir = __dirname;
     fs.mkdirSync(path.join(rootDir, "/public/uploads"), { recursive: true });
     cb(null, path.join(rootDir, "/public/uploads"));
   },


### PR DESCRIPTION
Changed `GET /uploads` endpoint's target directory to `/public/uploads` from `/
Replace `path.dirname(require.main.filename)` with `__dirname` in upload middleware

Fixes: #37